### PR TITLE
use segment_sum for mv_multiply

### DIFF
--- a/src/jaxga/ops/multiply.py
+++ b/src/jaxga/ops/multiply.py
@@ -49,8 +49,10 @@ def get_mv_multiply(a_blade_indices, b_blade_indices, signature, prod="gp"):
         out_indices = jnp.array(out_indices)
 
         def _values_mv_mul(a_values, b_values):
+            num_extra_dims = max(len(a_values), len(b_values)) - 1
+
             segment_out_values = (
-                out_signs * a_values[indices_a] * b_values[indices_b]
+                jnp.reshape(out_signs, (-1,) + (1,) * num_extra_dims) * a_values[indices_a] * b_values[indices_b]
             )
 
             out_values = jax.ops.segment_sum(

--- a/src/jaxga/ops/multiply.py
+++ b/src/jaxga/ops/multiply.py
@@ -43,18 +43,19 @@ def get_mv_multiply(a_blade_indices, b_blade_indices, signature, prod="gp"):
     else:
         out_size = max(out_indices) + 1
 
+        indices_a = jnp.array(indices_a)
+        indices_b = jnp.array(indices_b)
+        out_signs = jnp.array(out_signs, dtype=jnp.float32)
+        out_indices = jnp.array(out_indices)
+
         def _values_mv_mul(a_values, b_values):
-            out_batch_shape = jnp.broadcast_shapes(
-                a_values.shape[1:], b_values.shape[1:]
-            )
-            out_values = jnp.zeros(
-                [out_size, *out_batch_shape], dtype=jnp.float32
+            segment_out_values = (
+                out_signs * a_values[indices_a] * b_values[indices_b]
             )
 
-            for index_a, index_b, out_sign, out_index in zip(indices_a, indices_b, out_signs, out_indices):
-                out_values = out_values.at[out_index].add(
-                    out_sign * a_values[index_a] * b_values[index_b]
-                )
+            out_values = jax.ops.segment_sum(
+                segment_out_values, out_indices, num_segments=out_size
+            )
 
             return out_values
 


### PR DESCRIPTION
- Previously was using a loop and add at index which gets unrolled, now using `segment_sum` to sum same output indices
- 10x faster JIT on CPU, 6x faster JIT on GPU
- 100x slower runtime on CPU, 5x faster runtime on GPU

Should maybe add a flag for whether to use this one, very useful for large algebras where JIT takes very long because of analyzing the unrolled loop. Maybe make it the default on GPU too.

CPU results show segment_sum runtime very dependent on batch size
```
a_val, a_ind = jnp.array(jnp.ones([5, 10]), dtype=jnp.float32), tuple((i,) for i in range(5))
b_val, b_ind = jnp.array(jnp.ones([5, 10]), dtype=jnp.float32), tuple((i,i+1) for i in range(5))

new:
Wall time: 94 ms
10.8 µs ± 301 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

old:
Wall time: 1.04 s
10.9 µs ± 152 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

---
a_val, a_ind = jnp.array(jnp.ones([5, 100]), dtype=jnp.float32), tuple((i,) for i in range(5))
b_val, b_ind = jnp.array(jnp.ones([5, 100]), dtype=jnp.float32), tuple((i,i+1) for i in range(5))

new:
Wall time: 227 ms
48.6 µs ± 640 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

old:
Wall time: 676 ms
11.6 µs ± 464 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
---
a_val, a_ind = jnp.array(jnp.ones([10, 100]), dtype=jnp.float32), tuple((i,) for i in range(5))
b_val, b_ind = jnp.array(jnp.ones([10, 100]), dtype=jnp.float32), tuple((i,i+1) for i in range(5))

new:
Wall time: 261 ms
49.1 µs ± 1.49 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

old:
Wall time: 687 ms
11.6 µs ± 196 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
---
a_val, a_ind = jnp.array(jnp.ones([10, 1000]), dtype=jnp.float32), tuple((i,) for i in range(5))
b_val, b_ind = jnp.array(jnp.ones([10, 1000]), dtype=jnp.float32), tuple((i,i+1) for i in range(5))

new:
Wall time: 256 ms
1.19 ms ± 69.3 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

old:
Wall time: 558 ms
16.9 µs ± 234 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```